### PR TITLE
Fix json content-type

### DIFF
--- a/clients/src/rpc/mod.rs
+++ b/clients/src/rpc/mod.rs
@@ -72,7 +72,6 @@ where
     T: DeserializeOwned,
 {
     let mut header_map = HeaderMap::new();
-    header_map.insert(header::CONTENT_TYPE, HeaderValue::from_static("json"));
     if let Some(m) = additional_headers {
         for (k, v) in m {
             header_map.insert(


### PR DESCRIPTION
Currently the invalid content type header `json` is set, which will result in json parsers on the rpc providers to not parse the request body as json, because the correct content-type for json is `application/json`.

As the `.json()` method below in line 93 already sets the correct header (if it is not set yet) we can just remove this line.

Note: the chia node (rpc) ignores any content-type and always parses json from the raw string, hence the current code working for the node.