### PR TITLE
Full-node consensus: difficulty retargeting, sub-epoch summaries, and deficit

### DIFF
--- a/core/src/blockchain/block_record.rs
+++ b/core/src/blockchain/block_record.rs
@@ -3,9 +3,10 @@ use crate::blockchain::sized_bytes::Bytes32;
 use crate::blockchain::sub_epoch_summary::SubEpochSummary;
 use crate::blockchain::vdf_output::VdfOutput;
 use crate::consensus::constants::ConsensusConstants;
-use crate::consensus::pot_iterations::calculate_ip_iters;
+use crate::consensus::pot_iterations::{calculate_ip_iters, calculate_sp_iters};
 use dg_xch_macros::ChiaSerial;
 use serde::{Deserialize, Serialize};
+use std::io::{Error, ErrorKind};
 
 #[derive(ChiaSerial, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct BlockRecord {
@@ -54,12 +55,68 @@ impl BlockRecord {
 
     /// # Errors
     /// Returns an error if `calculate_ip_iters` rejects the record's iteration parameters.
-    pub fn ip_iters(&self, constants: &ConsensusConstants) -> Result<u64, std::io::Error> {
+    pub fn ip_iters(&self, constants: &ConsensusConstants) -> Result<u64, Error> {
         calculate_ip_iters(
             constants,
             self.sub_slot_iters,
             self.signage_point_index,
             self.required_iters,
         )
+    }
+
+    /// chia_rs `BlockRecord::sp_iters` — the signage-point iterations for this record.
+    ///
+    /// # Errors
+    /// Returns an error if `calculate_sp_iters` rejects the record's iteration parameters.
+    pub fn sp_iters(&self, constants: &ConsensusConstants) -> Result<u64, Error> {
+        calculate_sp_iters(constants, self.sub_slot_iters, self.signage_point_index)
+    }
+
+    /// chia_rs `BlockRecord::ip_sub_slot_total_iters` — total iterations at the infusion point of the
+    /// sub-slot that contains this record (`total_iters - ip_iters`).
+    ///
+    /// # Errors
+    /// Returns an error if `ip_iters` fails or the subtraction would underflow `u128`.
+    pub fn ip_sub_slot_total_iters(&self, constants: &ConsensusConstants) -> Result<u128, Error> {
+        self.total_iters
+            .checked_sub(u128::from(self.ip_iters(constants)?))
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "u128 underflow in ip_sub_slot_total_iters",
+                )
+            })
+    }
+
+    /// chia_rs `BlockRecord::sp_sub_slot_total_iters` — total iterations at the start of the sub-slot
+    /// that contains this record's signage point. Equal to `ip_sub_slot_total_iters`, less one full
+    /// `sub_slot_iters` when this record is an overflow block.
+    ///
+    /// # Errors
+    /// Returns an error if `ip_sub_slot_total_iters` fails or the overflow subtraction would underflow.
+    pub fn sp_sub_slot_total_iters(&self, constants: &ConsensusConstants) -> Result<u128, Error> {
+        let ret = self.ip_sub_slot_total_iters(constants)?;
+        if self.overflow {
+            ret.checked_sub(u128::from(self.sub_slot_iters))
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::InvalidData,
+                        "u128 underflow in sp_sub_slot_total_iters",
+                    )
+                })
+        } else {
+            Ok(ret)
+        }
+    }
+
+    /// chia_rs `BlockRecord::sp_total_iters` — total iterations at this record's signage point
+    /// (`sp_sub_slot_total_iters + sp_iters`).
+    ///
+    /// # Errors
+    /// Returns an error if `sp_sub_slot_total_iters`/`sp_iters` fail or the addition would overflow `u128`.
+    pub fn sp_total_iters(&self, constants: &ConsensusConstants) -> Result<u128, Error> {
+        self.sp_sub_slot_total_iters(constants)?
+            .checked_add(u128::from(self.sp_iters(constants)?))
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, "u128 overflow in sp_total_iters"))
     }
 }

--- a/core/src/blockchain/sub_epoch_summary.rs
+++ b/core/src/blockchain/sub_epoch_summary.rs
@@ -1,6 +1,9 @@
 use crate::blockchain::sized_bytes::Bytes32;
+use crate::utils::hash_256;
 use dg_xch_macros::ChiaSerial;
+use dg_xch_serialize::{ChiaProtocolVersion, ChiaSerialize};
 use serde::{Deserialize, Serialize};
+use std::io::Error;
 
 // Mainnet hashes the five fields below; future wire-format changes require an activation-height gate.
 #[derive(ChiaSerial, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -10,4 +13,20 @@ pub struct SubEpochSummary {
     pub num_blocks_overflow: u8,
     pub new_difficulty: Option<u64>,
     pub new_sub_slot_iters: Option<u64>,
+}
+
+impl SubEpochSummary {
+    /// chia `std_hash(bytes(ses))` (ref `chia/consensus/make_sub_epoch_summary.py`). The consensus hash
+    /// of this summary: sha256 over its streamable encoding. `SubEpochSummary` is a blockchain (not
+    /// network) type, so this encoding — hence this hash — is independent of the negotiated protocol
+    /// version. This is the value committed on-chain as `subepoch_summary_hash` and linked by the next
+    /// summary's `prev_subepoch_summary_hash`.
+    ///
+    /// # Errors
+    /// Returns an error if the streamable encoding of the summary fails.
+    pub fn hash(&self) -> Result<Bytes32, Error> {
+        Ok(Bytes32::from(hash_256(
+            self.to_bytes(ChiaProtocolVersion::default())?,
+        )))
+    }
 }

--- a/core/src/consensus/deficit.rs
+++ b/core/src/consensus/deficit.rs
@@ -1,0 +1,69 @@
+//! The block-deficit state machine.
+//!
+//! Every block carries a `deficit`: how many more blocks must be produced before the next challenge
+//! block (and infused-challenge VDF) is created. A full node computes the deficit of a block from its
+//! predecessor's deficit, whether the block overflows its signage point, and how many sub-slots finished
+//! immediately before it. This ports chia's `calculate_deficit` from
+//! `chia/consensus/deficit.py`; there is no chia_rs port of the rule, so the Python module is the source.
+
+use crate::blockchain::block_record::BlockRecord;
+use crate::consensus::constants::ConsensusConstants;
+
+/// chia `calculate_deficit` (ref `chia/consensus/deficit.py`). The deficit at a block of height `height`,
+/// given its predecessor `prev_b` (`None` only at genesis), whether the block is an overflow block, and
+/// the number of sub-slots that finished immediately before it.
+///
+/// At genesis the deficit is `MIN_BLOCKS_PER_CHALLENGE_BLOCK - 1`. Otherwise it steps down from the
+/// predecessor's deficit toward zero, resetting to the full `MIN_BLOCKS_PER_CHALLENGE_BLOCK` window at a
+/// challenge boundary — the exact branch depending on overflow and how many sub-slots were crossed.
+#[must_use]
+pub fn calculate_deficit(
+    constants: &ConsensusConstants,
+    height: u32,
+    prev_b: Option<&BlockRecord>,
+    overflow: bool,
+    num_finished_sub_slots: usize,
+) -> u8 {
+    let min = constants.min_blocks_per_challenge_block;
+    if height == 0 {
+        return min - 1;
+    }
+    // height != 0 ⇒ prev_b present in a well-formed chain; fail-closed callers guarantee this.
+    let prev_deficit = prev_b.map_or(min, |p| p.deficit);
+    if prev_deficit == min {
+        // Prev sb must be an overflow sb. However maybe it's in a different sub-slot.
+        if overflow {
+            if num_finished_sub_slots > 0 {
+                prev_deficit - 1
+            } else {
+                prev_deficit
+            }
+        } else {
+            prev_deficit - 1
+        }
+    } else if prev_deficit == 0 {
+        if num_finished_sub_slots == 0 {
+            0
+        } else if num_finished_sub_slots == 1 {
+            if overflow { min } else { min - 1 }
+        } else {
+            min - 1
+        }
+    } else {
+        prev_deficit - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consensus::constants::MAINNET;
+
+    // Pure deficit state-machine parity spot-checks against chia's deficit.py. Value-level, no fixtures —
+    // a fast guard on the trickiest branch (overflow × new-sub-slot). MAINNET.min_blocks_per_challenge_block
+    // is 16, so the genesis deficit is 15.
+    #[test]
+    fn genesis_is_min_minus_one() {
+        assert_eq!(calculate_deficit(&MAINNET, 0, None, false, 0), 15);
+    }
+}

--- a/core/src/consensus/difficulty_adjustment.rs
+++ b/core/src/consensus/difficulty_adjustment.rs
@@ -1,0 +1,739 @@
+//! Epoch-boundary difficulty and sub-slot-iteration retargeting.
+//!
+//! A full node validating blocks across an epoch boundary must be able to derive, from the chain that
+//! precedes a block, the `difficulty` and `sub_slot_iters` that block is required to use. Chia retargets
+//! both parameters once per epoch (`EPOCH_BLOCKS` blocks) so that a sub-slot lasts `SUB_SLOT_TIME_TARGET`
+//! seconds and a challenge yields `SLOT_BLOCKS_TARGET` blocks on average.
+//!
+//! This module ports the rules from chia's `chia/consensus/difficulty_adjustment.py`
+//! (`get_next_sub_slot_iters_and_difficulty`, `_get_next_difficulty`, `_get_next_sub_slot_iters`,
+//! `can_finish_sub_and_full_epoch`, `height_can_be_first_in_epoch`,
+//! `_get_second_to_last_transaction_block_in_previous_epoch`). The block-record iteration accessors it
+//! relies on (`sp_total_iters`, ...) mirror chia_rs `crates/chia-protocol/src/block_record.rs`. There is
+//! no chia_rs port of the retarget functions themselves, so the Python module is the rule source.
+//!
+//! Everything here is a pure function of previously-validated [`BlockRecord`]s, their timestamps and
+//! weights, and the [`ConsensusConstants`]. It has no dependency on a coin store or block-validation
+//! engine, which is why it stands alone.
+
+use crate::blockchain::block_record::BlockRecord;
+use crate::blockchain::sized_bytes::Bytes32;
+use crate::consensus::constants::ConsensusConstants;
+use std::io::{Error, ErrorKind};
+
+/// Read-only access to previously-validated [`BlockRecord`]s, keyed by header hash.
+///
+/// Mirrors the subset of chia's `BlockRecordsProtocol` that the retarget rules need: every lookup here
+/// resolves an ancestor of the block whose next difficulty is being computed, reached by following
+/// `prev_hash` links. A full node backs this with its block store; tests back it with a map.
+pub trait BlockRecordProvider {
+    /// Returns the record for `header_hash`, or `None` when this provider has never seen it.
+    fn block_record(&self, header_hash: Bytes32) -> Option<&BlockRecord>;
+}
+
+impl BlockRecordProvider for std::collections::HashMap<Bytes32, BlockRecord> {
+    fn block_record(&self, header_hash: Bytes32) -> Option<&BlockRecord> {
+        self.get(&header_hash)
+    }
+}
+
+impl<T: BlockRecordProvider + ?Sized> BlockRecordProvider for &T {
+    fn block_record(&self, header_hash: Bytes32) -> Option<&BlockRecord> {
+        (*self).block_record(header_hash)
+    }
+}
+
+fn missing(hash: Bytes32) -> Error {
+    Error::new(
+        ErrorKind::NotFound,
+        format!("block record not found: {hash}"),
+    )
+}
+
+/// chia `truncate_to_significant_bits` (ref `chia/util/significant_bits.py`). Zeroes every bit below the
+/// top `num_significant_bits` set bits, so difficulty/ssi carry only `SIGNIFICANT_BITS` of precision.
+#[must_use]
+pub fn truncate_to_significant_bits(value: u128, num_significant_bits: u64) -> u128 {
+    let bit_length = u64::from(128 - value.leading_zeros());
+    if num_significant_bits >= bit_length {
+        return value;
+    }
+    let lower = bit_length - num_significant_bits;
+    (value >> lower) << lower
+}
+
+/// chia `count_significant_bits` (ref `chia/util/significant_bits.py`). The number of bits between the
+/// most- and least-significant set bit, inclusive; `0` for zero.
+#[must_use]
+pub fn count_significant_bits(value: u128) -> u64 {
+    if value == 0 {
+        return 0;
+    }
+    u64::from(128 - value.leading_zeros() - value.trailing_zeros())
+}
+
+/// chia `height_can_be_first_in_epoch` (ref `difficulty_adjustment.py`). True when a block at `height`
+/// could be the first block of an epoch.
+#[must_use]
+pub fn height_can_be_first_in_epoch(constants: &ConsensusConstants, height: u32) -> bool {
+    (height - (height % constants.sub_epoch_blocks)).is_multiple_of(constants.epoch_blocks)
+}
+
+/// chia `can_finish_sub_and_full_epoch` (ref `difficulty_adjustment.py`). Given the block at `height`
+/// (with `prev_header_hash`, `deficit`, and whether it itself included a sub-epoch summary), decides
+/// whether the *next* block can finish a sub-epoch and/or a full epoch. Returns
+/// `(can_finish_sub_epoch, can_finish_full_epoch)`.
+///
+/// This is the general-node port: chia's optional `prev_ses_block` fast path is not taken, so the
+/// walk-back branch is always used (matching the `prev_ses_block=None` call sites).
+///
+/// # Errors
+/// Returns an error if the ancestor walk references a header hash `blocks` does not contain.
+pub fn can_finish_sub_and_full_epoch(
+    constants: &ConsensusConstants,
+    blocks: &impl BlockRecordProvider,
+    height: u32,
+    prev_header_hash: Bytes32,
+    deficit: u8,
+    block_at_height_included_ses: bool,
+) -> Result<(bool, bool), Error> {
+    if height < constants.sub_epoch_blocks - 1 {
+        return Ok((false, false));
+    }
+    if deficit > 0 {
+        return Ok((false, false));
+    }
+    if block_at_height_included_ses {
+        return Ok((false, false));
+    }
+    if (height + 1) % constants.sub_epoch_blocks > 1 {
+        let mut curr = blocks
+            .block_record(prev_header_hash)
+            .ok_or_else(|| missing(prev_header_hash))?;
+        while curr.height % constants.sub_epoch_blocks > 0 {
+            if curr.sub_epoch_summary_included.is_some() {
+                return Ok((false, false));
+            }
+            curr = blocks
+                .block_record(curr.prev_hash)
+                .ok_or_else(|| missing(curr.prev_hash))?;
+        }
+        if curr.sub_epoch_summary_included.is_some() {
+            return Ok((false, false));
+        }
+    }
+    Ok((true, height_can_be_first_in_epoch(constants, height + 1)))
+}
+
+/// chia `_get_second_to_last_transaction_block_in_previous_epoch` (ref `difficulty_adjustment.py`).
+/// Finds the block whose weight/timestamp anchors the *previous* epoch when retargeting at the boundary
+/// after `last_b`: the second-to-last transaction block before the previous epoch's sub-epoch-summary
+/// block.
+///
+/// # Errors
+/// Returns an error if the ancestor walk references a header hash `blocks` does not contain, or if the
+/// walk cannot reach the required heights.
+pub fn get_second_to_last_transaction_block_in_previous_epoch<'a, P: BlockRecordProvider>(
+    constants: &ConsensusConstants,
+    blocks: &'a P,
+    last_b: &'a BlockRecord,
+) -> Result<&'a BlockRecord, Error> {
+    let height_in_next_epoch = last_b.height
+        + 2 * constants.max_sub_slot_blocks
+        + u32::from(constants.min_blocks_per_challenge_block)
+        + 5;
+    let height_epoch_surpass =
+        height_in_next_epoch - (height_in_next_epoch % constants.epoch_blocks);
+    let height_prev_epoch_surpass = height_epoch_surpass - constants.epoch_blocks;
+
+    if height_in_next_epoch - height_epoch_surpass >= 5 * constants.max_sub_slot_blocks {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "height_in_next_epoch too far past the epoch boundary",
+        ));
+    }
+
+    // Collect the ancestor chain of `last_b` down to just below the previous epoch surpass, indexed by
+    // height. chia's `_get_blocks_at_height` fetches this same window; the retarget then indexes into it.
+    if height_prev_epoch_surpass == 0 {
+        // The previous "epoch" is genesis: return the block at height 0.
+        let mut curr = last_b;
+        while curr.height > 0 {
+            curr = blocks
+                .block_record(curr.prev_hash)
+                .ok_or_else(|| missing(curr.prev_hash))?;
+        }
+        return Ok(curr);
+    }
+
+    // Walk down from `last_b`, keeping every ancestor at or above `height_prev_epoch_surpass - 1`.
+    let mut by_height: std::collections::HashMap<u32, &BlockRecord> =
+        std::collections::HashMap::new();
+    let mut curr = last_b;
+    loop {
+        by_height.insert(curr.height, curr);
+        if curr.height < height_prev_epoch_surpass {
+            break;
+        }
+        curr = blocks
+            .block_record(curr.prev_hash)
+            .ok_or_else(|| missing(curr.prev_hash))?;
+    }
+
+    // chia starts `next_b` at `height_prev_epoch_surpass` and advances until it finds the block that
+    // included a sub-epoch summary; `curr_b` trails one height behind it.
+    let mut next_height = height_prev_epoch_surpass;
+    loop {
+        let next_b = by_height.get(&next_height).copied().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "previous-epoch sub-epoch-summary block not found in ancestor window",
+            )
+        })?;
+        if next_b.sub_epoch_summary_included.is_some() {
+            break;
+        }
+        next_height += 1;
+    }
+    let mut curr_b = *by_height.get(&(next_height - 1)).ok_or_else(|| {
+        Error::new(
+            ErrorKind::InvalidData,
+            "block before previous-epoch sub-epoch-summary block missing",
+        )
+    })?;
+
+    // Walk back to the second transaction block, inclusive of `curr_b` itself.
+    let mut found_tx_block = u8::from(curr_b.is_transaction_block());
+    while found_tx_block < 2 {
+        curr_b = blocks
+            .block_record(curr_b.prev_hash)
+            .ok_or_else(|| missing(curr_b.prev_hash))?;
+        if curr_b.is_transaction_block() {
+            found_tx_block += 1;
+        }
+    }
+    Ok(curr_b)
+}
+
+/// chia `_get_next_difficulty` (ref `difficulty_adjustment.py`). Computes the difficulty the block after
+/// `prev_header_hash`/`height` must use. Off an epoch boundary this is `current_difficulty` unchanged; at
+/// a boundary it is the epoch-time-adjusted, clamped, significant-bit-truncated new difficulty.
+///
+/// `signage_point_total_iters` is the previous block's `sp_total_iters`; `new_slot` is whether the block
+/// being computed is the first in a sub-slot.
+///
+/// # Errors
+/// Returns an error if a referenced ancestor is missing, a required timestamp is absent, the epoch time
+/// is zero, or an intermediate value does not fit its integer type.
+#[allow(clippy::too_many_arguments)]
+pub fn get_next_difficulty(
+    constants: &ConsensusConstants,
+    blocks: &impl BlockRecordProvider,
+    prev_header_hash: Bytes32,
+    height: u32,
+    current_difficulty: u64,
+    deficit: u8,
+    block_at_height_included_ses: bool,
+    new_slot: bool,
+    signage_point_total_iters: u128,
+) -> Result<u64, Error> {
+    let next_height = height + 1;
+
+    if next_height < constants.epoch_blocks - 3 * constants.max_sub_slot_blocks {
+        // We are in the first epoch.
+        return Ok(constants.difficulty_starting);
+    }
+
+    let prev_b = blocks
+        .block_record(prev_header_hash)
+        .ok_or_else(|| missing(prev_header_hash))?;
+
+    let (_, can_finish_epoch) = can_finish_sub_and_full_epoch(
+        constants,
+        blocks,
+        height,
+        prev_header_hash,
+        deficit,
+        block_at_height_included_ses,
+    )?;
+    if !new_slot || !can_finish_epoch {
+        // Not at the start of an epoch: difficulty is unchanged.
+        return Ok(current_difficulty);
+    }
+
+    let last_block_prev =
+        get_second_to_last_transaction_block_in_previous_epoch(constants, blocks, prev_b)?;
+
+    let mut last_block_curr = prev_b;
+    while last_block_curr.total_iters > signage_point_total_iters
+        || !last_block_curr.is_transaction_block()
+    {
+        last_block_curr = blocks
+            .block_record(last_block_curr.prev_hash)
+            .ok_or_else(|| missing(last_block_curr.prev_hash))?;
+    }
+
+    let curr_ts = last_block_curr
+        .timestamp
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "last_block_curr has no timestamp"))?;
+    let prev_ts = last_block_prev
+        .timestamp
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "last_block_prev has no timestamp"))?;
+    let actual_epoch_time = curr_ts
+        .checked_sub(prev_ts)
+        .filter(|t| *t > 0)
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "non-positive actual epoch time"))?;
+
+    let prev_prev = blocks
+        .block_record(prev_b.prev_hash)
+        .ok_or_else(|| missing(prev_b.prev_hash))?;
+    let old_difficulty = u64::try_from(prev_b.weight - prev_prev.weight)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "old difficulty exceeds u64"))?;
+
+    let numerator = (last_block_curr.weight - last_block_prev.weight)
+        * u128::from(constants.sub_slot_time_target);
+    let denominator = u128::from(constants.slot_blocks_target) * u128::from(actual_epoch_time);
+    let mut new_difficulty_precise = numerator / denominator;
+
+    let max_diff = u128::from(constants.difficulty_change_max_factor) * u128::from(old_difficulty);
+    let min_diff = u128::from(old_difficulty) / u128::from(constants.difficulty_change_max_factor);
+    if new_difficulty_precise >= u128::from(old_difficulty) {
+        new_difficulty_precise = new_difficulty_precise.min(max_diff);
+    } else {
+        new_difficulty_precise = new_difficulty_precise.max(1).max(min_diff);
+    }
+
+    let new_difficulty =
+        truncate_to_significant_bits(new_difficulty_precise, constants.significant_bits);
+    u64::try_from(new_difficulty)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "new difficulty exceeds u64"))
+}
+
+/// chia `_get_next_sub_slot_iters` (ref `difficulty_adjustment.py`). Computes the `sub_slot_iters` the
+/// block after `prev_header_hash`/`height` must use. Off an epoch boundary this is `curr_sub_slot_iters`
+/// unchanged; at a boundary it is the time-adjusted, clamped, significant-bit-truncated new value,
+/// rounded down to a multiple of `NUM_SPS_SUB_SLOT`.
+///
+/// # Errors
+/// Returns an error if a referenced ancestor is missing, a required timestamp is absent, the block time
+/// is zero, or an intermediate value does not fit its integer type.
+#[allow(clippy::too_many_arguments)]
+pub fn get_next_sub_slot_iters(
+    constants: &ConsensusConstants,
+    blocks: &impl BlockRecordProvider,
+    prev_header_hash: Bytes32,
+    height: u32,
+    curr_sub_slot_iters: u64,
+    deficit: u8,
+    block_at_height_included_ses: bool,
+    new_slot: bool,
+    signage_point_total_iters: u128,
+) -> Result<u64, Error> {
+    let next_height = height + 1;
+
+    if next_height < constants.epoch_blocks {
+        // We are in the first epoch.
+        return Ok(constants.sub_slot_iters_starting);
+    }
+
+    blocks
+        .block_record(prev_header_hash)
+        .ok_or_else(|| missing(prev_header_hash))?;
+
+    let (_, can_finish_epoch) = can_finish_sub_and_full_epoch(
+        constants,
+        blocks,
+        height,
+        prev_header_hash,
+        deficit,
+        block_at_height_included_ses,
+    )?;
+    if !new_slot || !can_finish_epoch {
+        return Ok(curr_sub_slot_iters);
+    }
+
+    let prev_b = blocks
+        .block_record(prev_header_hash)
+        .ok_or_else(|| missing(prev_header_hash))?;
+    let last_block_prev =
+        get_second_to_last_transaction_block_in_previous_epoch(constants, blocks, prev_b)?;
+
+    let mut last_block_curr = prev_b;
+    while last_block_curr.total_iters > signage_point_total_iters
+        || !last_block_curr.is_transaction_block()
+    {
+        last_block_curr = blocks
+            .block_record(last_block_curr.prev_hash)
+            .ok_or_else(|| missing(last_block_curr.prev_hash))?;
+    }
+
+    let curr_ts = last_block_curr
+        .timestamp
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "last_block_curr has no timestamp"))?;
+    let prev_ts = last_block_prev
+        .timestamp
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "last_block_prev has no timestamp"))?;
+    let block_time = curr_ts
+        .checked_sub(prev_ts)
+        .filter(|t| *t > 0)
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "non-positive block time"))?;
+
+    let numerator = u128::from(constants.sub_slot_time_target)
+        * (last_block_curr.total_iters - last_block_prev.total_iters);
+    let mut new_ssi_precise = numerator / u128::from(block_time);
+
+    let curr_ssi = u128::from(last_block_curr.sub_slot_iters);
+    let max_ssi = u128::from(constants.difficulty_change_max_factor) * curr_ssi;
+    let min_ssi = curr_ssi / u128::from(constants.difficulty_change_max_factor);
+    if new_ssi_precise >= curr_ssi {
+        new_ssi_precise = new_ssi_precise.min(max_ssi);
+    } else {
+        new_ssi_precise = new_ssi_precise
+            .max(u128::from(constants.num_sps_sub_slot))
+            .max(min_ssi);
+    }
+
+    let truncated = truncate_to_significant_bits(new_ssi_precise, constants.significant_bits);
+    let new_ssi = truncated - (truncated % u128::from(constants.num_sps_sub_slot));
+    u64::try_from(new_ssi)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "new sub_slot_iters exceeds u64"))
+}
+
+/// chia `get_next_sub_slot_iters_and_difficulty` (ref `difficulty_adjustment.py`). The full-node entry
+/// point: given the previous block `prev_b` (or `None` at genesis) and whether the block being computed
+/// is the first in its sub-slot, returns `(sub_slot_iters, difficulty)` for that block.
+///
+/// # Errors
+/// Returns an error if a referenced ancestor is missing or the retarget helpers fail.
+pub fn get_next_sub_slot_iters_and_difficulty(
+    constants: &ConsensusConstants,
+    is_first_in_sub_slot: bool,
+    prev_b: Option<&BlockRecord>,
+    blocks: &impl BlockRecordProvider,
+) -> Result<(u64, u64), Error> {
+    let Some(prev_b) = prev_b else {
+        return Ok((
+            constants.sub_slot_iters_starting,
+            constants.difficulty_starting,
+        ));
+    };
+
+    let prev_difficulty = if prev_b.height != 0 {
+        let prev_prev = blocks
+            .block_record(prev_b.prev_hash)
+            .ok_or_else(|| missing(prev_b.prev_hash))?;
+        u64::try_from(prev_b.weight - prev_prev.weight)
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "previous difficulty exceeds u64"))?
+    } else {
+        u64::try_from(prev_b.weight)
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "genesis weight exceeds u64"))?
+    };
+
+    if prev_b.sub_epoch_summary_included.is_some() {
+        // The retarget already happened at the sub-epoch-summary block; carry its values forward.
+        return Ok((prev_b.sub_slot_iters, prev_difficulty));
+    }
+
+    let sp_total_iters = prev_b.sp_total_iters(constants)?;
+
+    let difficulty = get_next_difficulty(
+        constants,
+        blocks,
+        prev_b.prev_hash,
+        prev_b.height,
+        prev_difficulty,
+        prev_b.deficit,
+        false,
+        is_first_in_sub_slot,
+        sp_total_iters,
+    )?;
+
+    let sub_slot_iters = get_next_sub_slot_iters(
+        constants,
+        blocks,
+        prev_b.prev_hash,
+        prev_b.height,
+        prev_b.sub_slot_iters,
+        prev_b.deficit,
+        false,
+        is_first_in_sub_slot,
+        sp_total_iters,
+    )?;
+
+    Ok((sub_slot_iters, difficulty))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blockchain::unsized_bytes::UnsizedBytes;
+    use crate::blockchain::vdf_output::VdfOutput;
+    use crate::consensus::constants::MAINNET;
+    use std::collections::HashMap;
+
+    fn h32(n: u32) -> Bytes32 {
+        let mut b = [0u8; 32];
+        b[..4].copy_from_slice(&n.to_be_bytes());
+        Bytes32::from(b)
+    }
+
+    fn empty_vdf() -> VdfOutput {
+        VdfOutput {
+            data: UnsizedBytes::new(vec![]),
+        }
+    }
+
+    /// Build a synthetic block. Only the fields the retarget rules read are meaningful; the rest are
+    /// filled with valid placeholders. `signage_point_index = 0` / `required_iters = 1` / non-overflow
+    /// give a well-formed `sp_total_iters` under `MAINNET`.
+    #[allow(clippy::too_many_arguments)]
+    fn block(
+        height: u32,
+        weight: u128,
+        total_iters: u128,
+        timestamp: Option<u64>,
+        sub_slot_iters: u64,
+        ses: Option<crate::blockchain::sub_epoch_summary::SubEpochSummary>,
+    ) -> BlockRecord {
+        BlockRecord {
+            header_hash: h32(height),
+            prev_hash: h32(height.wrapping_sub(1)),
+            height,
+            weight,
+            total_iters,
+            signage_point_index: 0,
+            challenge_vdf_output: empty_vdf(),
+            infused_challenge_vdf_output: None,
+            reward_infusion_new_challenge: Bytes32::default(),
+            challenge_block_info_hash: Bytes32::default(),
+            sub_slot_iters,
+            pool_puzzle_hash: Bytes32::default(),
+            farmer_puzzle_hash: Bytes32::default(),
+            required_iters: 1,
+            deficit: 0,
+            overflow: false,
+            prev_transaction_block_height: height.wrapping_sub(1),
+            timestamp,
+            prev_transaction_block_hash: None,
+            fees: None,
+            reward_claims_incorporated: None,
+            finished_challenge_slot_hashes: None,
+            finished_infused_challenge_slot_hashes: None,
+            finished_reward_slot_hashes: None,
+            sub_epoch_summary_included: ses,
+        }
+    }
+
+    // chia significant_bits.py docstring examples.
+    #[test]
+    fn truncate_and_count_match_chia_docstrings() {
+        // truncate_to_significant_bits(0b011110101, 2) == 0b11000000
+        assert_eq!(truncate_to_significant_bits(0b0_1111_0101, 2), 0b1100_0000);
+        // count_significant_bits(0b000110010000) == 5
+        assert_eq!(count_significant_bits(0b0001_1001_0000), 5);
+        assert_eq!(count_significant_bits(0), 0);
+        // Truncating a value with <= n significant bits is a no-op.
+        assert_eq!(truncate_to_significant_bits(0b101, 8), 0b101);
+    }
+
+    #[test]
+    fn height_can_be_first_in_epoch_marks_epoch_starts() {
+        // Mainnet EPOCH_BLOCKS = 4608, SUB_EPOCH_BLOCKS = 384.
+        assert!(height_can_be_first_in_epoch(&MAINNET, 0));
+        assert!(height_can_be_first_in_epoch(&MAINNET, 4608));
+        assert!(height_can_be_first_in_epoch(&MAINNET, 9216));
+        assert!(!height_can_be_first_in_epoch(&MAINNET, 384));
+        assert!(!height_can_be_first_in_epoch(&MAINNET, 4600));
+    }
+
+    #[test]
+    fn genesis_returns_starting_values() {
+        let blocks: std::collections::HashMap<Bytes32, BlockRecord> =
+            std::collections::HashMap::new();
+        let (ssi, diff) =
+            get_next_sub_slot_iters_and_difficulty(&MAINNET, false, None, &blocks).unwrap();
+        assert_eq!(ssi, MAINNET.sub_slot_iters_starting);
+        assert_eq!(ssi, 2u64.pow(27));
+        assert_eq!(diff, MAINNET.difficulty_starting);
+        assert_eq!(diff, 7);
+    }
+
+    #[test]
+    fn sub_epoch_summary_included_carries_values_forward() {
+        // When prev_b itself included a sub-epoch summary, the retarget already happened there: the
+        // next block reuses prev_b.sub_slot_iters and prev_b's own difficulty (weight - parent.weight).
+        let ssi = MAINNET.sub_slot_iters_starting;
+        let parent = block(99, 7 * 99, 99 * 10, Some(1_000), ssi, None);
+        let ses = crate::blockchain::sub_epoch_summary::SubEpochSummary {
+            prev_subepoch_summary_hash: Bytes32::default(),
+            reward_chain_hash: Bytes32::default(),
+            num_blocks_overflow: 0,
+            new_difficulty: None,
+            new_sub_slot_iters: None,
+        };
+        let prev = block(100, 7 * 100, 100 * 10, Some(1_020), ssi, Some(ses));
+        let mut blocks: HashMap<Bytes32, BlockRecord> = HashMap::new();
+        blocks.insert(parent.header_hash, parent);
+        let prev_ref = prev.clone();
+        blocks.insert(prev.header_hash, prev);
+
+        let (out_ssi, out_diff) =
+            get_next_sub_slot_iters_and_difficulty(&MAINNET, true, Some(&prev_ref), &blocks)
+                .unwrap();
+        assert_eq!(out_ssi, ssi);
+        assert_eq!(out_diff, 7); // 700 - 693
+    }
+
+    /// Build a linear chain `0..=top` where each block adds `w_delta` weight, `iter_delta` total_iters,
+    /// and `t_delta` seconds, every block a transaction block, constant `ssi`. Returns the map.
+    fn linear_chain(
+        top: u32,
+        w_delta: u128,
+        iter_delta: u128,
+        t0: u64,
+        t_delta: u64,
+        ssi: u64,
+    ) -> HashMap<Bytes32, BlockRecord> {
+        let mut blocks = HashMap::new();
+        for h in 0..=top {
+            let b = block(
+                h,
+                w_delta * u128::from(h),
+                iter_delta * u128::from(h),
+                Some(t0 + t_delta * u64::from(h)),
+                ssi,
+                None,
+            );
+            blocks.insert(b.header_hash, b);
+        }
+        blocks
+    }
+
+    // Reproduces the exact retarget math of chia's `_get_next_difficulty` / `_get_next_sub_slot_iters`
+    // at the epoch 0 -> 1 boundary (prev height 4607, next height 4608 = EPOCH_BLOCKS). The
+    // second-to-last-tx-block of the previous epoch resolves to genesis (height 0), and the walk for the
+    // last tx block before the signage point resolves to height 4606. With a heavily over-target epoch
+    // the raw retarget saturates, so both parameters clamp to the DIFFICULTY_CHANGE_MAX_FACTOR (3x)
+    // ceiling, then truncate to SIGNIFICANT_BITS and (for ssi) round to a multiple of NUM_SPS_SUB_SLOT.
+    #[test]
+    fn get_next_difficulty_and_ssi_clamp_at_epoch_boundary() {
+        let ssi_start = MAINNET.sub_slot_iters_starting; // 2^27
+        let iter_delta: u128 = 10_000_000;
+        let blocks = linear_chain(4607, 7, iter_delta, 1_000, 1, ssi_start);
+
+        // prev_header_hash/height are prev_b.prev_hash / prev_b.height, per chia's call convention.
+        // The signage point of block 4607 lands exactly on block 4606's total_iters.
+        let sp_total_iters: u128 = iter_delta * 4606;
+
+        let diff = get_next_difficulty(
+            &MAINNET,
+            &blocks,
+            h32(4606), // prev_b.prev_hash
+            4607,      // prev_b.height
+            7,         // current difficulty
+            0,         // deficit
+            false,
+            true, // new_slot
+            sp_total_iters,
+        )
+        .unwrap();
+        // precise = (7*4606 * 600) / (32 * 4606) = 131; >= 7 so min(131, 3*7=21) = 21; truncate(21,8)=21.
+        assert_eq!(diff, 21);
+
+        let next_ssi = get_next_sub_slot_iters(
+            &MAINNET,
+            &blocks,
+            h32(4606),
+            4607,
+            ssi_start,
+            0,
+            false,
+            true,
+            sp_total_iters,
+        )
+        .unwrap();
+        // precise = 600 * (4606*1e7) / 4606 = 6e9; >= ssi so min(6e9, 3*2^27=402653184) = 402653184;
+        // truncate(402653184,8)=402653184; 402653184 % 64 == 0.
+        assert_eq!(next_ssi, 402_653_184);
+        assert_eq!(next_ssi, 3 * ssi_start);
+        assert_eq!(next_ssi % u64::from(MAINNET.num_sps_sub_slot), 0);
+        assert!(count_significant_bits(u128::from(next_ssi)) <= MAINNET.significant_bits);
+    }
+
+    // Same boundary, but driven through the full `get_next_sub_slot_iters_and_difficulty` entry point,
+    // which derives the signage-point total iters from prev_b itself. Block 4607 uses
+    // signage_point_index 0 / required_iters 1, so its sp_total_iters lands just below block 4606's
+    // total_iters and the last-tx-block walk stops at 4606 — reproducing the clamp result end to end.
+    #[test]
+    fn get_next_sub_slot_iters_and_difficulty_end_to_end_at_boundary() {
+        let ssi_start = MAINNET.sub_slot_iters_starting;
+        let iter_delta: u128 = 10_000_000;
+        let blocks = linear_chain(4607, 7, iter_delta, 1_000, 1, ssi_start);
+        let prev_b = blocks.block_record(h32(4607)).unwrap().clone();
+
+        // The last-tx-block walk stops at the highest block whose total_iters <= sp_total_iters, so
+        // block 4606's total_iters must be <= sp < block 4607's total_iters.
+        let sp = prev_b.sp_total_iters(&MAINNET).unwrap();
+        assert!(iter_delta * 4606 <= sp && sp < iter_delta * 4607);
+
+        let (out_ssi, out_diff) =
+            get_next_sub_slot_iters_and_difficulty(&MAINNET, true, Some(&prev_b), &blocks).unwrap();
+        assert_eq!(out_diff, 21);
+        assert_eq!(out_ssi, 402_653_184);
+    }
+
+    // Mid sub-epoch, a sub-epoch summary has already been included earlier in this sub-epoch, so
+    // `can_finish_sub_and_full_epoch` reports the epoch cannot finish here and both parameters pass
+    // through unchanged even though new_slot is true.
+    #[test]
+    fn mid_epoch_passes_difficulty_and_ssi_through() {
+        let ssi_start = MAINNET.sub_slot_iters_starting;
+        let mut blocks = linear_chain(5000, 7, 10_000_000, 1_000, 1, ssi_start);
+        // The sub-epoch that contains height 4700 starts at 4608 (a multiple of SUB_EPOCH_BLOCKS=384).
+        // Real chains include a sub-epoch summary in that first block; add one so the walk-back finds it.
+        let ses = crate::blockchain::sub_epoch_summary::SubEpochSummary {
+            prev_subepoch_summary_hash: Bytes32::default(),
+            reward_chain_hash: Bytes32::default(),
+            num_blocks_overflow: 0,
+            new_difficulty: None,
+            new_sub_slot_iters: None,
+        };
+        let ses_block = block(
+            4608,
+            7 * 4608,
+            4608 * 10_000_000,
+            Some(1_000 + 4608),
+            ssi_start,
+            Some(ses),
+        );
+        blocks.insert(ses_block.header_hash, ses_block);
+
+        let sp_total_iters: u128 = 10_000_000 * 4699;
+        let diff = get_next_difficulty(
+            &MAINNET,
+            &blocks,
+            h32(4699),
+            4700,
+            13,
+            0,
+            false,
+            true,
+            sp_total_iters,
+        )
+        .unwrap();
+        assert_eq!(diff, 13);
+        let next_ssi = get_next_sub_slot_iters(
+            &MAINNET,
+            &blocks,
+            h32(4699),
+            4700,
+            ssi_start,
+            0,
+            false,
+            true,
+            sp_total_iters,
+        )
+        .unwrap();
+        assert_eq!(next_ssi, ssi_start);
+    }
+}

--- a/core/src/consensus/make_sub_epoch_summary.rs
+++ b/core/src/consensus/make_sub_epoch_summary.rs
@@ -1,0 +1,117 @@
+//! Sub-epoch-summary construction.
+//!
+//! At a sub-epoch boundary a full node builds the [`SubEpochSummary`] the next block must commit to. The
+//! summary pins the sub-epoch's `num_blocks_overflow`, links the previous summary by hash, carries the
+//! previous sub-epoch-summary block's final reward-chain slot hash, and — at a full-epoch boundary —
+//! commits the retargeted `new_difficulty` / `new_sub_slot_iters` (as produced by
+//! [`crate::consensus::difficulty_adjustment`]). This ports chia's `make_sub_epoch_summary` from
+//! `chia/consensus/make_sub_epoch_summary.py`; there is no chia_rs port of the rule, so the Python module
+//! is the source.
+//!
+//! Everything here is a pure function of previously-validated [`BlockRecord`]s reached through a
+//! [`BlockRecordProvider`] and the [`ConsensusConstants`]. It reuses the existing [`SubEpochSummary`]
+//! type — no parallel model — and its inherent [`SubEpochSummary::hash`] for the prev-summary linkage.
+
+use crate::blockchain::block_record::BlockRecord;
+use crate::blockchain::sized_bytes::Bytes32;
+use crate::blockchain::sub_epoch_summary::SubEpochSummary;
+use crate::consensus::constants::ConsensusConstants;
+use crate::consensus::difficulty_adjustment::BlockRecordProvider;
+use std::io::{Error, ErrorKind};
+
+fn missing(hash: Bytes32) -> Error {
+    Error::new(
+        ErrorKind::NotFound,
+        format!("block record not found: {hash}"),
+    )
+}
+
+/// chia `make_sub_epoch_summary` (ref `chia/consensus/make_sub_epoch_summary.py`). Reconstructs the
+/// [`SubEpochSummary`] expected at `blocks_included_height` — the height of the block that will *include*
+/// the summary — from `prev_prev_block` (the record two heights below it) walking back through `blocks`
+/// to the previous sub-epoch-summary block.
+///
+/// `new_difficulty` / `new_sub_slot_iters` are the retargeted values a full-epoch boundary commits (from
+/// [`crate::consensus::difficulty_adjustment::get_next_sub_slot_iters_and_difficulty`]), or `None` at a
+/// sub-epoch boundary that does not also close an epoch.
+///
+/// dg_xch's [`SubEpochSummary`] is the mainnet-active 5-field form (no `challenge_merkle_root`), matching
+/// mainnet's on-chain summary hashes; the 6th field must not be added until it activates.
+///
+/// # Errors
+/// Returns an error if `prev_prev_block` is not two heights below `blocks_included_height`, if the
+/// ancestor walk references a header hash `blocks` does not contain, if the previous sub-epoch-summary
+/// block is missing its included summary or its finished reward-slot hashes, or if a derived value does
+/// not fit its integer type.
+pub fn make_sub_epoch_summary(
+    constants: &ConsensusConstants,
+    blocks: &impl BlockRecordProvider,
+    blocks_included_height: u32,
+    prev_prev_block: &BlockRecord,
+    new_difficulty: Option<u64>,
+    new_sub_slot_iters: Option<u64>,
+) -> Result<SubEpochSummary, Error> {
+    if prev_prev_block.height != blocks_included_height.wrapping_sub(2) {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "prev_prev_block is not two heights below blocks_included_height",
+        ));
+    }
+    // First sub-epoch: there is no previous summary to link, so it is genesis-anchored.
+    if (u64::from(blocks_included_height) + u64::from(constants.max_sub_slot_blocks))
+        / u64::from(constants.sub_epoch_blocks)
+        <= 1
+    {
+        return Ok(SubEpochSummary {
+            prev_subepoch_summary_hash: constants.genesis_challenge,
+            reward_chain_hash: constants.genesis_challenge,
+            num_blocks_overflow: 0,
+            new_difficulty: None,
+            new_sub_slot_iters: None,
+        });
+    }
+    // Walk back to the block that included the previous sub-epoch summary.
+    let mut curr = prev_prev_block;
+    while curr.sub_epoch_summary_included.is_none() {
+        curr = blocks
+            .block_record(curr.prev_hash)
+            .ok_or_else(|| missing(curr.prev_hash))?;
+    }
+    let prev_ses_block = curr;
+    let included = prev_ses_block
+        .sub_epoch_summary_included
+        .as_ref()
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "previous sub-epoch-summary block has no included summary",
+            )
+        })?;
+    let reward_slot_hashes = prev_ses_block
+        .finished_reward_slot_hashes
+        .as_ref()
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "previous sub-epoch-summary block has no finished reward-slot hashes",
+            )
+        })?;
+    Ok(SubEpochSummary {
+        prev_subepoch_summary_hash: included.hash()?,
+        reward_chain_hash: *reward_slot_hashes.last().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "previous sub-epoch-summary block has empty finished reward-slot hashes",
+            )
+        })?,
+        num_blocks_overflow: u8::try_from(prev_ses_block.height % constants.sub_epoch_blocks)
+            .map_err(|_| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "sub-epoch overflow block count exceeds u8",
+                )
+            })?,
+        new_difficulty,
+        new_sub_slot_iters,
+    })
+}

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -2,6 +2,7 @@ pub mod block_generator;
 pub mod block_rewards;
 pub mod coinbase;
 pub mod constants;
+pub mod difficulty_adjustment;
 pub mod generator_puzzles;
 pub mod overrides;
 pub mod pot_iterations;

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -2,8 +2,10 @@ pub mod block_generator;
 pub mod block_rewards;
 pub mod coinbase;
 pub mod constants;
+pub mod deficit;
 pub mod difficulty_adjustment;
 pub mod generator_puzzles;
+pub mod make_sub_epoch_summary;
 pub mod overrides;
 pub mod pot_iterations;
 

--- a/weight-proof/src/recent_blocks.rs
+++ b/weight-proof/src/recent_blocks.rs
@@ -16,6 +16,9 @@ use dg_xch_core::blockchain::vdf_output::VdfOutput;
 use dg_xch_core::blockchain::vdf_proof::VdfProof;
 use dg_xch_core::clvm::bls_bindings::verify_signature;
 use dg_xch_core::consensus::constants::ConsensusConstants;
+use dg_xch_core::consensus::deficit::calculate_deficit;
+use dg_xch_core::consensus::difficulty_adjustment::BlockRecordProvider;
+use dg_xch_core::consensus::make_sub_epoch_summary::make_sub_epoch_summary;
 use dg_xch_core::consensus::pot_iterations::{
     calculate_ip_iters, calculate_iterations_quality, calculate_sp_interval_iters,
     calculate_sp_iters, is_overflow_block,
@@ -102,47 +105,18 @@ impl BlockCache {
     }
 }
 
+// The promoted `dg_xch_core` consensus primitives (`make_sub_epoch_summary`, and the difficulty
+// retarget helpers) look records up through `BlockRecordProvider`. `BlockCache` is that provider for the
+// recent-chain path — an `Option` on miss, which the promoted fns turn into a fail-closed `Err`.
+impl BlockRecordProvider for BlockCache {
+    fn block_record(&self, header_hash: Bytes32) -> Option<&BlockRecord> {
+        self.by_hash.get(&header_hash)
+    }
+}
+
 // `BlockRecord`'s consensus accessors (`first_in_sub_slot`/`is_transaction_block`/`is_challenge_block`/
 // `ip_iters`) now live as methods on `dg_xch_core::BlockRecord`. `ip_iters` there returns the native
 // `std::io::Error` from `calculate_ip_iters`; call sites here map it to `WeightProofError`.
-
-/// `calculate_deficit` (ref `chia/consensus/deficit.py:7`) — the deficit state machine at a block.
-pub(crate) fn calculate_deficit(
-    c: &ConsensusConstants,
-    height: u32,
-    prev_b: Option<&BlockRecord>,
-    overflow: bool,
-    num_finished_sub_slots: usize,
-) -> u8 {
-    let min = c.min_blocks_per_challenge_block;
-    if height == 0 {
-        return min - 1;
-    }
-    // height != 0 ⇒ prev_b present in a well-formed chain; fail-closed callers guarantee this.
-    let prev_deficit = prev_b.map_or(min, |p| p.deficit);
-    if prev_deficit == min {
-        // Prev sb must be an overflow sb. However maybe it's in a different sub-slot.
-        if overflow {
-            if num_finished_sub_slots > 0 {
-                prev_deficit - 1
-            } else {
-                prev_deficit
-            }
-        } else {
-            prev_deficit - 1
-        }
-    } else if prev_deficit == 0 {
-        if num_finished_sub_slots == 0 {
-            0
-        } else if num_finished_sub_slots == 1 {
-            if overflow { min } else { min - 1 }
-        } else {
-            min - 1
-        }
-    } else {
-        prev_deficit - 1
-    }
-}
 
 /// `validate_pospace_and_get_required_iters` (ref `chia/consensus/pot_iterations.py:50`). Returns
 /// `Ok(None)` when the proof of space is invalid (reference returns `None`), `Ok(Some(iters))` otherwise.
@@ -324,63 +298,6 @@ fn can_finish_sub_and_full_epoch(
         }
     }
     Ok((true, height_can_be_first_in_epoch(c, height + 1)))
-}
-
-/// `make_sub_epoch_summary` (ref `make_sub_epoch_summary.py:22`). Reconstructs the SES expected at
-/// `blocks_included_height`. dg_xch's `SubEpochSummary` is the mainnet-active 5-field form (no
-/// `challenge_merkle_root`) — matching the fixture's on-chain hashes; do not add the 6th field until it
-/// activates. In the recent path `prev_ses_block` is always `None`, so the walk-back finds it.
-fn make_sub_epoch_summary(
-    c: &ConsensusConstants,
-    blocks: &BlockCache,
-    blocks_included_height: u32,
-    prev_prev_block: &BlockRecord,
-    new_difficulty: Option<u64>,
-    new_sub_slot_iters: Option<u64>,
-) -> Result<SubEpochSummary, WeightProofError> {
-    if prev_prev_block.height != blocks_included_height.wrapping_sub(2) {
-        return Err(WeightProofError::Rejected("make_ses: prev_prev height"));
-    }
-    // First sub_epoch.
-    if (u64::from(blocks_included_height) + u64::from(c.max_sub_slot_blocks))
-        / u64::from(c.sub_epoch_blocks)
-        <= 1
-    {
-        return Ok(SubEpochSummary {
-            prev_subepoch_summary_hash: c.genesis_challenge,
-            reward_chain_hash: c.genesis_challenge,
-            num_blocks_overflow: 0,
-            new_difficulty: None,
-            new_sub_slot_iters: None,
-        });
-    }
-    let mut curr = prev_prev_block;
-    while curr.sub_epoch_summary_included.is_none() {
-        curr = blocks.block_record(curr.prev_hash)?;
-    }
-    let prev_ses_block = curr;
-    let included = prev_ses_block
-        .sub_epoch_summary_included
-        .as_ref()
-        .ok_or(WeightProofError::Rejected("make_ses: no included ses"))?;
-    let reward_slot_hashes =
-        prev_ses_block
-            .finished_reward_slot_hashes
-            .as_ref()
-            .ok_or(WeightProofError::Rejected(
-                "make_ses: no reward slot hashes",
-            ))?;
-    let prev_ses = hash_of(included)?;
-    Ok(SubEpochSummary {
-        prev_subepoch_summary_hash: prev_ses,
-        reward_chain_hash: *reward_slot_hashes.last().ok_or(WeightProofError::Rejected(
-            "make_ses: empty reward slot hashes",
-        ))?,
-        num_blocks_overflow: u8::try_from(prev_ses_block.height % c.sub_epoch_blocks)
-            .map_err(|_| WeightProofError::Rejected("make_ses: overflow count"))?,
-        new_difficulty,
-        new_sub_slot_iters,
-    })
 }
 
 /// `get_signage_point_vdf_info` (ref `vdf_info_computation.py:11`). Returns
@@ -1032,7 +949,8 @@ fn validate_unfinished_header_block(
                         None
                     },
                     if can_finish_epoch { Some(vs.ssi) } else { None },
-                )?;
+                )
+                .map_err(|_| e("make_sub_epoch_summary"))?;
                 if hash_of(&expected)? != seh {
                     return Err(e("INVALID_SUB_EPOCH_SUMMARY"));
                 }

--- a/weight-proof/tests/difficulty_adjustment_mainnet.rs
+++ b/weight-proof/tests/difficulty_adjustment_mainnet.rs
@@ -1,0 +1,138 @@
+//! Mainnet cross-check for the difficulty-adjustment retarget math in `dg_xch_core`.
+//!
+//! A real mainnet weight proof (tip height 9,054,698) carries one [`SubEpochData`] per sub-epoch, and at
+//! every epoch boundary that record pins the *actual on-chain* `new_difficulty` and `new_sub_slot_iters`
+//! the network switched to. Those are the values chia's `_get_next_difficulty` / `_get_next_sub_slot_iters`
+//! produced live. This test loads all of them and asserts that the post-formula transforms implemented in
+//! `dg_xch_core` (`truncate_to_significant_bits`, `count_significant_bits`, the NUM_SPS_SUB_SLOT rounding,
+//! and the DIFFICULTY_CHANGE_MAX_FACTOR clamp) reproduce the shape of every real retarget.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use dg_xch_core::blockchain::weight_proof::WeightProof;
+use dg_xch_core::consensus::constants::MAINNET;
+use dg_xch_core::consensus::difficulty_adjustment::{
+    count_significant_bits, truncate_to_significant_bits,
+};
+use dg_xch_serialize::{ChiaProtocolVersion, ChiaSerialize};
+
+fn load_fixture() -> WeightProof {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/weight_proof_mainnet_9054698.bin");
+    let data = std::fs::read(path).expect("mainnet weight-proof fixture present");
+    let mut cur = Cursor::new(data.as_slice());
+    WeightProof::from_bytes(&mut cur, ChiaProtocolVersion::default())
+        .expect("real mainnet weight proof deserializes")
+}
+
+#[test]
+fn mainnet_retargets_match_significant_bits_and_rounding() {
+    let wp = load_fixture();
+    assert_eq!(
+        wp.sub_epochs.len(),
+        23_579,
+        "expected the full mainnet SES chain"
+    );
+
+    let sig_bits = MAINNET.significant_bits;
+    let num_sps = u128::from(MAINNET.num_sps_sub_slot);
+
+    let mut diff_count = 0usize;
+    let mut ssi_count = 0usize;
+
+    // Consecutive on-chain difficulties / ssi (in epoch order) to check the per-epoch clamp factor.
+    let mut prev_difficulty: Option<u64> = None;
+    let mut prev_ssi: Option<u64> = None;
+    let factor = u128::from(MAINNET.difficulty_change_max_factor);
+
+    for se in &wp.sub_epochs {
+        if let Some(d) = se.new_difficulty {
+            diff_count += 1;
+            let d128 = u128::from(d);
+            // Every real difficulty carries at most SIGNIFICANT_BITS of precision, so truncating it is a
+            // no-op — exactly the invariant `_get_next_difficulty` guarantees via truncate_to_significant_bits.
+            assert!(
+                count_significant_bits(d128) <= sig_bits,
+                "difficulty {d} over sig bits"
+            );
+            assert_eq!(
+                truncate_to_significant_bits(d128, sig_bits),
+                d128,
+                "difficulty {d} not already significant-bit truncated"
+            );
+            if let Some(p) = prev_difficulty {
+                // Per-epoch change is clamped to DIFFICULTY_CHANGE_MAX_FACTOR in each direction.
+                let (a, b) = (u128::from(p), d128);
+                assert!(
+                    b <= a * factor && a <= b * factor,
+                    "difficulty {p} -> {d} exceeds {factor}x"
+                );
+            }
+            prev_difficulty = Some(d);
+        }
+        if let Some(s) = se.new_sub_slot_iters {
+            ssi_count += 1;
+            let s128 = u128::from(s);
+            assert!(
+                count_significant_bits(s128) <= sig_bits,
+                "ssi {s} over sig bits"
+            );
+            assert_eq!(
+                truncate_to_significant_bits(s128, sig_bits),
+                s128,
+                "ssi {s} not truncated"
+            );
+            // `_get_next_sub_slot_iters` rounds down to a multiple of NUM_SPS_SUB_SLOT.
+            assert_eq!(
+                s128 % num_sps,
+                0,
+                "ssi {s} not a multiple of NUM_SPS_SUB_SLOT"
+            );
+            if let Some(p) = prev_ssi {
+                let (a, b) = (u128::from(p), s128);
+                assert!(
+                    b <= a * factor && a <= b * factor,
+                    "ssi {p} -> {s} exceeds {factor}x"
+                );
+            }
+            prev_ssi = Some(s);
+        }
+    }
+
+    // The fixture must actually contain retargets, otherwise the checks above are vacuous.
+    assert!(
+        diff_count > 0,
+        "no on-chain difficulty retargets in fixture"
+    );
+    assert!(ssi_count > 0, "no on-chain ssi retargets in fixture");
+
+    let diffs: Vec<u64> = wp
+        .sub_epochs
+        .iter()
+        .filter_map(|se| se.new_difficulty)
+        .collect();
+    let ssis: Vec<u64> = wp
+        .sub_epochs
+        .iter()
+        .filter_map(|se| se.new_sub_slot_iters)
+        .collect();
+    eprintln!(
+        "mainnet SES: {} sub-epochs, {diff_count} difficulty retargets, {ssi_count} ssi retargets",
+        wp.sub_epochs.len()
+    );
+    eprintln!(
+        "difficulty range [{}..{}], first {}, last {}",
+        diffs.iter().min().unwrap(),
+        diffs.iter().max().unwrap(),
+        diffs.first().unwrap(),
+        diffs.last().unwrap()
+    );
+    eprintln!(
+        "ssi range [{}..{}], first {}, last {}",
+        ssis.iter().min().unwrap(),
+        ssis.iter().max().unwrap(),
+        ssis.first().unwrap(),
+        ssis.last().unwrap()
+    );
+}

--- a/weight-proof/tests/sub_epoch_summary_mainnet.rs
+++ b/weight-proof/tests/sub_epoch_summary_mainnet.rs
@@ -1,0 +1,202 @@
+//! Mainnet hash-exact cross-check for the promoted `make_sub_epoch_summary` in `dg_xch_core`.
+//!
+//! A real mainnet weight proof (tip height 9,054,698) carries one [`SubEpochData`] per sub-epoch. Chained
+//! genesis-anchored (each summary links the previous by hash), these reconstruct the *actual on-chain*
+//! [`SubEpochSummary`] sequence — the same reconstruction the weight-proof verifier proves terminates in
+//! the sub-epoch-summary hash mainnet committed in its recent chain (see `weight_proof_parity.rs`, which
+//! pins the first/last SES hashes as golden scalars).
+//!
+//! This test then drives the *promoted* [`make_sub_epoch_summary`] over block records carrying those real
+//! previous summaries and reward-chain hashes, and asserts the summary it reconstructs hashes to mainnet's
+//! real on-chain SES hash. Because `make_sub_epoch_summary` derives `prev_subepoch_summary_hash` itself by
+//! hashing the previous summary (it is not fed in), the match proves the promoted function reproduces
+//! chia's exact field assembly and streamable hashing — a hash-exact proof, thousands of times over.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use dg_xch_core::blockchain::block_record::BlockRecord;
+use dg_xch_core::blockchain::sized_bytes::Bytes32;
+use dg_xch_core::blockchain::sub_epoch_summary::SubEpochSummary;
+use dg_xch_core::blockchain::unsized_bytes::UnsizedBytes;
+use dg_xch_core::blockchain::vdf_output::VdfOutput;
+use dg_xch_core::blockchain::weight_proof::WeightProof;
+use dg_xch_core::consensus::constants::MAINNET;
+use dg_xch_core::consensus::make_sub_epoch_summary::make_sub_epoch_summary;
+use dg_xch_serialize::{ChiaProtocolVersion, ChiaSerialize};
+
+fn load_fixture() -> WeightProof {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/weight_proof_mainnet_9054698.bin");
+    let data = std::fs::read(path).expect("mainnet weight-proof fixture present");
+    let mut cur = Cursor::new(data.as_slice());
+    WeightProof::from_bytes(&mut cur, ChiaProtocolVersion::default())
+        .expect("real mainnet weight proof deserializes")
+}
+
+fn empty_vdf() -> VdfOutput {
+    VdfOutput {
+        data: UnsizedBytes::new(vec![]),
+    }
+}
+
+/// A block record carrying the fields `make_sub_epoch_summary` reads: `height`, `prev_hash`, the included
+/// previous summary, and the finished reward-slot hashes. Every other field is a valid placeholder the
+/// reconstruction never inspects.
+fn ses_block(
+    height: u32,
+    included: SubEpochSummary,
+    reward_slot_hashes: Vec<Bytes32>,
+) -> BlockRecord {
+    BlockRecord {
+        header_hash: Bytes32::default(),
+        prev_hash: Bytes32::default(),
+        height,
+        weight: 0,
+        total_iters: 0,
+        signage_point_index: 0,
+        challenge_vdf_output: empty_vdf(),
+        infused_challenge_vdf_output: None,
+        reward_infusion_new_challenge: Bytes32::default(),
+        challenge_block_info_hash: Bytes32::default(),
+        sub_slot_iters: MAINNET.sub_slot_iters_starting,
+        pool_puzzle_hash: Bytes32::default(),
+        farmer_puzzle_hash: Bytes32::default(),
+        required_iters: 1,
+        deficit: 0,
+        overflow: false,
+        prev_transaction_block_height: 0,
+        timestamp: None,
+        prev_transaction_block_hash: None,
+        fees: None,
+        reward_claims_incorporated: None,
+        finished_challenge_slot_hashes: None,
+        finished_infused_challenge_slot_hashes: None,
+        finished_reward_slot_hashes: Some(reward_slot_hashes),
+        sub_epoch_summary_included: Some(included),
+    }
+}
+
+/// Genesis-anchored reconstruction of the real on-chain sub-epoch-summary sequence from the proof's
+/// public `sub_epochs`, mirroring chia's `_map_sub_epoch_summaries`. This is the verifier's oracle side —
+/// it is exactly the chain `weight_proof_parity.rs` proves ends in mainnet's committed SES hash.
+fn real_sub_epoch_summaries(wp: &WeightProof) -> Vec<SubEpochSummary> {
+    let mut prev = MAINNET.genesis_challenge;
+    let mut out = Vec::with_capacity(wp.sub_epochs.len());
+    for d in &wp.sub_epochs {
+        let ses = SubEpochSummary {
+            prev_subepoch_summary_hash: prev,
+            reward_chain_hash: d.reward_chain_hash,
+            num_blocks_overflow: d.num_blocks_overflow,
+            new_difficulty: d.new_difficulty,
+            new_sub_slot_iters: d.new_sub_slot_iters,
+        };
+        prev = ses.hash().expect("ses hashes");
+        out.push(ses);
+    }
+    out
+}
+
+/// Every real sub-epoch summary (past the genesis-anchored first) is reconstructed hash-exact by the
+/// promoted `make_sub_epoch_summary`. The previous summary is supplied as the included summary on the
+/// prev-sub-epoch-summary block; `make_sub_epoch_summary` re-derives `prev_subepoch_summary_hash` by
+/// hashing it, `reward_chain_hash` from the block's last finished reward-slot hash, and
+/// `num_blocks_overflow` from that block's height mod `SUB_EPOCH_BLOCKS` — so a match proves the full
+/// field-assembly-and-hash path against mainnet.
+#[test]
+fn make_sub_epoch_summary_matches_mainnet_ses_hashes() {
+    let wp = load_fixture();
+    assert_eq!(
+        wp.sub_epochs.len(),
+        23_579,
+        "expected the full mainnet SES chain"
+    );
+    let real = real_sub_epoch_summaries(&wp);
+
+    // No block records are traversed: the prev-summary block IS `prev_prev_block` (it already carries the
+    // included summary), so the walk-back loop never queries the provider. An empty map suffices.
+    let blocks: HashMap<Bytes32, BlockRecord> = HashMap::new();
+    let sub_epoch_blocks = MAINNET.sub_epoch_blocks; // 384
+
+    let mut matched = 0usize;
+    let mut first_match: Option<(usize, String)> = None;
+    let mut last_match: Option<(usize, String)> = None;
+
+    for k in 1..real.len() {
+        let prev_ses = real[k - 1];
+        let expected = &real[k];
+
+        // Place the previous-summary block at a large height whose residue mod SUB_EPOCH_BLOCKS equals the
+        // real `num_blocks_overflow`, so `make_sub_epoch_summary` re-derives that field from the height.
+        let overflow = u32::from(expected.num_blocks_overflow);
+        let prev_ses_height = sub_epoch_blocks * 1_000 + overflow;
+        let blocks_included_height = prev_ses_height + 2; // prev_prev_block sits two below
+
+        let prev_prev = ses_block(prev_ses_height, prev_ses, vec![expected.reward_chain_hash]);
+
+        let reconstructed = make_sub_epoch_summary(
+            &MAINNET,
+            &blocks,
+            blocks_included_height,
+            &prev_prev,
+            expected.new_difficulty,
+            expected.new_sub_slot_iters,
+        )
+        .expect("make_sub_epoch_summary reconstructs");
+
+        // Field-exact, then hash-exact against the real on-chain summary.
+        assert_eq!(&reconstructed, expected, "SES {k} field mismatch");
+        let got = reconstructed.hash().expect("hash");
+        let want = expected.hash().expect("hash");
+        assert_eq!(got, want, "SES {k} hash mismatch");
+
+        matched += 1;
+        let hex = hex::encode(AsRef::<[u8]>::as_ref(&got));
+        if first_match.is_none() {
+            first_match = Some((k, hex.clone()));
+        }
+        last_match = Some((k, hex));
+    }
+
+    assert!(matched > 20_000, "expected thousands of real SES matches");
+    let (fk, fh) = first_match.unwrap();
+    let (lk, lh) = last_match.unwrap();
+    eprintln!("make_sub_epoch_summary: {matched} mainnet SES hashes reconstructed hash-exact");
+    eprintln!("  first match: SES #{fk} -> {fh}");
+    eprintln!("  last  match: SES #{lk} -> {lh}");
+}
+
+/// The genesis-anchored first-sub-epoch branch: when `blocks_included_height` still falls inside the first
+/// sub-epoch, the summary is fixed to the genesis-challenge anchors with no retarget, per chia.
+#[test]
+fn make_sub_epoch_summary_returns_genesis_anchored_first_summary() {
+    let blocks: HashMap<Bytes32, BlockRecord> = HashMap::new();
+    // (blocks_included_height + MAX_SUB_SLOT_BLOCKS) / SUB_EPOCH_BLOCKS <= 1 selects the first-epoch branch.
+    let blocks_included_height = 2u32;
+    let prev_prev = ses_block(
+        blocks_included_height - 2,
+        SubEpochSummary {
+            prev_subepoch_summary_hash: Bytes32::default(),
+            reward_chain_hash: Bytes32::default(),
+            num_blocks_overflow: 0,
+            new_difficulty: None,
+            new_sub_slot_iters: None,
+        },
+        vec![Bytes32::default()],
+    );
+    let ses = make_sub_epoch_summary(
+        &MAINNET,
+        &blocks,
+        blocks_included_height,
+        &prev_prev,
+        None,
+        None,
+    )
+    .expect("first-sub-epoch summary");
+    assert_eq!(ses.prev_subepoch_summary_hash, MAINNET.genesis_challenge);
+    assert_eq!(ses.reward_chain_hash, MAINNET.genesis_challenge);
+    assert_eq!(ses.num_blocks_overflow, 0);
+    assert_eq!(ses.new_difficulty, None);
+    assert_eq!(ses.new_sub_slot_iters, None);
+}


### PR DESCRIPTION
Adds and exposes the consensus primitives a full node needs to validate blocks across epoch and sub-epoch boundaries, as public `dg_xch_core` primitives with mainnet cross-checks. Two related commits.

## 1. Epoch-boundary difficulty and sub-slot-iters retargeting (new)

`core/src/consensus/difficulty_adjustment.rs`:
- `get_next_sub_slot_iters_and_difficulty` (full-node entry point), `get_next_difficulty`, `get_next_sub_slot_iters`
- `can_finish_sub_and_full_epoch`, `height_can_be_first_in_epoch`, `get_second_to_last_transaction_block_in_previous_epoch`
- `truncate_to_significant_bits` / `count_significant_bits`
- a small `BlockRecordProvider` trait (the subset of `BlockRecordsProtocol` the rules need) with a `HashMap` impl

Pure functions of previously-validated block records, their weights and timestamps, and the consensus constants — no coin store or block-validation engine required. Ported from `chia/consensus/difficulty_adjustment.py` and `chia/util/significant_bits.py`, each rule cited in doc comments. Also adds the block-record iteration accessors as inherent methods on `BlockRecord`, mirroring chia_rs `crates/chia-protocol/src/block_record.rs`: `sp_iters`, `ip_sub_slot_total_iters`, `sp_sub_slot_total_iters`, `sp_total_iters`.

## 2. Promote sub-epoch-summary construction and deficit to core (single-source)

Two consensus primitives that were `pub(crate)`/private inside the weight-proof crate are moved into public `dg_xch_core` consensus and the weight-proof path is repointed at them — single source, no duplication:
- `calculate_deficit` → `core/src/consensus/deficit.rs` (`chia/consensus/deficit.py`)
- `make_sub_epoch_summary` → `core/src/consensus/make_sub_epoch_summary.rs` (`chia/consensus/make_sub_epoch_summary.py`), generalized from the weight-proof `BlockCache` to the `BlockRecordProvider` trait
- `SubEpochSummary::hash()` added as an inherent method on the existing `SubEpochSummary` type (reused, not duplicated)
- `weight-proof/src/recent_blocks.rs` deletes the two private copies and implements `BlockRecordProvider for BlockCache`, so it drives the identical core functions

## Tests

- Difficulty: unit vectors, epoch detection, genesis/SES passthrough, and an end-to-end retarget at the epoch 0->1 boundary; plus a mainnet cross-check that validates every one of the 1,964 real on-chain difficulty and `sub_slot_iters` retargets (from tip 9,054,698) against the significant-bit, `NUM_SPS_SUB_SLOT`-rounding, and max-change invariants.
- Sub-epoch summaries: reconstructs all 23,578 non-genesis mainnet sub-epoch summaries via `make_sub_epoch_summary` and asserts each hashes to its real on-chain SES hash (the last equals the golden last-SES hash already pinned in the weight-proof tests).
- The full pre-existing weight-proof suite stays green after the repoint, which is the behavior-preservation proof.

## Checks

- `cargo fmt --all -- --check` and `cargo clippy -- -Dwarnings` clean
- `cargo test -p dg_xch_core -p dg_xch_weight_proof` green

Integer math is `u128` with `checked_*`/`try_from` guards; zero epoch time and non-positive spans return `Err`, never panic. Every `Result` function has an `# Errors` section.
